### PR TITLE
Update requirements.txt to fix paho-mqtt issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ aiofiles==24.1.0
 homeassistant==2024.9.3
 pydantic==2.9.2
 types-aiofiles==24.1.0.20240626
-types-paho-mqtt==1.6.0.20240321
+types-paho-mqtt==2.1.0


### PR DESCRIPTION
The integration does not work on HA 2025.3 due to HA using a newer version of `paho-mqtt` instead of 1.6.1. I’ve changed `requirements.txt` for the newest version 2.1.0