### PR TITLE
Update manifest.json to fix paho-mqtt version issue

### DIFF
--- a/custom_components/anycubic_cloud/manifest.json
+++ b/custom_components/anycubic_cloud/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/WaresWichall/anycubic_cloud/issues",
   "loggers": [],
-  "requirements": ["paho-mqtt==1.6.1"],
+  "requirements": ["paho-mqtt"],
   "version": "0.2.2"
 }


### PR DESCRIPTION
There has been an issue since updating to HA Core 2025.3 due to a conflict in the version of `paho-mqtt`. I changed the dependency in `custom_components/anycubic_cloud/manifest.json` (as suggested by @Hwoarang002 in issue #41).

After installing, the integration does work on my Home Assistant. I’m using Web login (no MQTT).

